### PR TITLE
Add unique setname

### DIFF
--- a/releases/_alternatives/R-Type II (inv) (World).mra
+++ b/releases/_alternatives/R-Type II (inv) (World).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
     <name>R-Type II (Inv) (World)</name>
     <mameversion>0245</mameversion>
-    <setname>rtype2</setname>
+    <setname>rtype2inv</setname>
     <version>Invincibility</version>
     <year>1989</year>
     <manufacturer>Irem</manufacturer>

--- a/releases/_alternatives/X Multiply (Inv) (Japan, M72 hardware).mra
+++ b/releases/_alternatives/X Multiply (Inv) (Japan, M72 hardware).mra
@@ -1,7 +1,7 @@
 <misterromdescription>
     <name>X Multiply (Inv) (Japan, M72 hardware)</name>
     <mameversion>0245</mameversion>
-    <setname>xmultiplm72</setname>
+    <setname>xmultiplm72inv</setname>
     <version>Invincibility</version>
     <parent>xmultipl</parent>
     <year>1989</year>


### PR DESCRIPTION
Right now, it has the same setname as the non inv mras. Since it is not part of mame, I have added a unique setname. It will help the arcade organizer